### PR TITLE
Bump citools to 1.3.3, githubbuild to 1.7.1, soup to 1.4.40

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.3.2'
+      tag: '1.3.3'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'actionlint'

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.7.0'
+      tag: '1.7.1'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.4.39'
+      tag: '1.4.40'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'


### PR DESCRIPTION
# Summary

Update Homebrew formula versions to their latest releases.

**Key changes:**
- Bump citools from 1.3.2 to 1.3.3
- Bump githubbuild from 1.7.0 to 1.7.1
- Bump soup from 1.4.39 to 1.4.40

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bump only, no logic changes
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
