### PR TITLE
Fix gem resource installation failing in all formulas

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -296,8 +296,7 @@ class Citools < Formula
 
     resources.each do |r|
       r.verify_download_integrity(r.fetch)
-      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor") ||
-        raise("Failed to install gem: #{r.name}")
+      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor")
     end
 
     rm_rf('vendor')

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -287,8 +287,7 @@ class Githubbuild < Formula
 
     resources.each do |r|
       r.verify_download_integrity(r.fetch)
-      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor") ||
-        raise("Failed to install gem: #{r.name}")
+      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor")
     end
 
     rm_rf('vendor')

--- a/soup.rb
+++ b/soup.rb
@@ -288,8 +288,7 @@ class Soup < Formula
 
     resources.each do |r|
       r.verify_download_integrity(r.fetch)
-      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor") ||
-        raise("Failed to install gem: #{r.name}")
+      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor")
     end
 
     rm_rf('vendor')


### PR DESCRIPTION
## Summary
- Remove `|| raise(...)` guard from `system('gem', 'install', ...)` calls in all three formulas (citools, githubbuild, soup)
- Homebrew's `Formula#system` returns `nil` on success (bare `return`), not `true`, so the `|| raise(...)` was always triggered — even when gems installed successfully
- The guard was also redundant since Homebrew's `system` already raises `BuildError` on command failure

## Test plan
- [ ] `brew install citools` completes successfully
- [ ] `brew install githubbuild` completes successfully
- [ ] `brew install soup` completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)