### PR TITLE
Fix gem install and bump citools 1.3.8, githubbuild 1.10.1, soup 1.4.45

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -4,3 +4,6 @@ line-length: false
 no-duplicate-heading: false
 single-h1: false
 tables: false
+no-inline-html:
+  allowed_elements:
+    - br

--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.3.7'
+      tag: '1.3.8'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -33,8 +33,8 @@ class Citools < Formula
   end
 
   resource 'aws-partitions' do
-    url 'https://rubygems.org/gems/aws-partitions-1.1212.0.gem'
-    sha256 'fa4f5de905cc2b6587747e5b1e2d215e610fa0449c70b9069e3c928a15cc2a15'
+    url 'https://rubygems.org/gems/aws-partitions-1.1213.0.gem'
+    sha256 '5ec132d91d44ef2702125b8f71f0e4fc2cd7de040e02c5d0aefb87219fd2e05e'
   end
 
   resource 'aws-sdk-autoscaling' do

--- a/citools.rb
+++ b/citools.rb
@@ -296,8 +296,7 @@ class Citools < Formula
 
     resources.each do |r|
       r.verify_download_integrity(r.fetch)
-      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor") ||
-        raise("Failed to install gem: #{r.name}")
+      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor")
     end
 
     rm_rf('vendor')

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.10.0'
+      tag: '1.10.1'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -287,8 +287,7 @@ class Githubbuild < Formula
 
     resources.each do |r|
       r.verify_download_integrity(r.fetch)
-      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor") ||
-        raise("Failed to install gem: #{r.name}")
+      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor")
     end
 
     rm_rf('vendor')

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.4.44'
+      tag: '1.4.45'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'

--- a/soup.rb
+++ b/soup.rb
@@ -288,8 +288,7 @@ class Soup < Formula
 
     resources.each do |r|
       r.verify_download_integrity(r.fetch)
-      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor") ||
-        raise("Failed to install gem: #{r.name}")
+      system('gem', 'install', r.cached_download, '--no-document', '--install-dir', "#{libexec}/vendor")
     end
 
     rm_rf('vendor')


### PR DESCRIPTION
## Summary

Fix gem resource installation that was broken in all formulas and bump tool versions.

**Key changes:**

- Remove `|| raise(...)` guard from `system('gem', 'install', ...)` calls in citools.rb, githubbuild.rb, and soup.rb. Homebrew's `Formula#system` returns nil on success, so the raise was always triggered even when gems installed successfully. Homebrew already raises `BuildError` on failure, making the guard redundant.
- Bump citools from 1.3.7 to 1.3.8
- Bump githubbuild from 1.10.0 to 1.10.1
- Bump soup from 1.4.44 to 1.4.45
- Update aws-partitions gem resource from 1.1212.0 to 1.1213.0 in citools.rb
- Add `no-inline-html` allowed elements configuration for `<br>` in .markdownlint.yml

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Homebrew formula changes are validated during installation
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
