### PR TITLE
Bump citools 1.5.0, githubbuild 1.12.0, soup 1.6.0 and update dependencies

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.4.0'
+      tag: '1.5.0'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -68,8 +68,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-ec2' do
-    url 'https://rubygems.org/gems/aws-sdk-ec2-1.605.0.gem'
-    sha256 '76790715d0f13fe4c5431d9455b02123f9da4faab9403f8ed5a22f3b197ed629'
+    url 'https://rubygems.org/gems/aws-sdk-ec2-1.606.0.gem'
+    sha256 '6e578f87771217a681b967da7aa355a3968dcfa130fd22a8d82f5309056bc840'
   end
 
   resource 'aws-sdk-elasticloadbalancingv2' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.11.0'
+      tag: '1.12.0'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.5.0'
+      tag: '1.6.0'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'


### PR DESCRIPTION
## Summary

Bump formula versions for citools, githubbuild, and soup to their latest releases, along with updated gem dependencies.

**Key changes:**
- Bump citools from 1.4.0 to 1.5.0
- Bump githubbuild from 1.11.0 to 1.12.0
- Bump soup from 1.5.0 to 1.6.0
- Update aws-sdk-ec2 gem from 1.605.0 to 1.606.0 in citools formula

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bumps only, no new logic to test
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
