### PR TITLE
Bump citools 1.5.1, githubbuild 1.12.1, soup 1.6.1 and update dependencies

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.5.0'
+      tag: '1.5.1'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -23,8 +23,8 @@ class Citools < Formula
   depends_on 'yamllint'
 
   resource 'addressable' do
-    url 'https://rubygems.org/gems/addressable-2.8.8.gem'
-    sha256 '7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057'
+    url 'https://rubygems.org/gems/addressable-2.8.9.gem'
+    sha256 'cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485'
   end
 
   resource 'ast' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.12.0'
+      tag: '1.12.1'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -15,8 +15,8 @@ class Githubbuild < Formula
   end
 
   resource 'addressable' do
-    url 'https://rubygems.org/gems/addressable-2.8.8.gem'
-    sha256 '7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057'
+    url 'https://rubygems.org/gems/addressable-2.8.9.gem'
+    sha256 'cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485'
   end
 
   resource 'ast' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.0'
+      tag: '1.6.1'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -15,8 +15,8 @@ class Soup < Formula
   end
 
   resource 'addressable' do
-    url 'https://rubygems.org/gems/addressable-2.8.8.gem'
-    sha256 '7c13b8f9536cf6364c03b9d417c19986019e28f7c00ac8132da4eb0fe393b057'
+    url 'https://rubygems.org/gems/addressable-2.8.9.gem'
+    sha256 'cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485'
   end
 
   resource 'ast' do


### PR DESCRIPTION
## Summary

Bump formula versions and update shared dependency across all formulas.

**Key changes:**
- Bump citools from 1.5.0 to 1.5.1
- Bump githubbuild from 1.12.0 to 1.12.1
- Bump soup from 1.6.0 to 1.6.1
- Update addressable gem from 2.8.8 to 2.8.9 in citools, githubbuild, and soup formulas

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bump and dependency update only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
