### PR TITLE
Bump citools 1.5.2, githubbuild 1.13.0, soup 1.6.2 and update dependencies

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.5.1'
+      tag: '1.5.2'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -168,8 +168,8 @@ class Citools < Formula
   end
 
   resource 'mcp' do
-    url 'https://rubygems.org/gems/mcp-0.7.1.gem'
-    sha256 'fa967895d6952bad0d981ea907731d8528d2c246d2079d56a9c8bae83d14f1c7'
+    url 'https://rubygems.org/gems/mcp-0.8.0.gem'
+    sha256 'ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb'
   end
 
   resource 'mini_mime' do
@@ -274,8 +274,8 @@ class Citools < Formula
   end
 
   resource 'rspec-mocks' do
-    url 'https://rubygems.org/gems/rspec-mocks-3.13.7.gem'
-    sha256 '0979034e64b1d7a838aaaddf12bf065ea4dc40ef3d4c39f01f93ae2c66c62b1c'
+    url 'https://rubygems.org/gems/rspec-mocks-3.13.8.gem'
+    sha256 '086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47'
   end
 
   resource 'rspec-support' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.12.1'
+      tag: '1.13.0'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -120,8 +120,8 @@ class Githubbuild < Formula
   end
 
   resource 'mcp' do
-    url 'https://rubygems.org/gems/mcp-0.7.1.gem'
-    sha256 'fa967895d6952bad0d981ea907731d8528d2c246d2079d56a9c8bae83d14f1c7'
+    url 'https://rubygems.org/gems/mcp-0.8.0.gem'
+    sha256 'ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb'
   end
 
   resource 'mini_mime' do
@@ -205,8 +205,8 @@ class Githubbuild < Formula
   end
 
   resource 'rspec-mocks' do
-    url 'https://rubygems.org/gems/rspec-mocks-3.13.7.gem'
-    sha256 '0979034e64b1d7a838aaaddf12bf065ea4dc40ef3d4c39f01f93ae2c66c62b1c'
+    url 'https://rubygems.org/gems/rspec-mocks-3.13.8.gem'
+    sha256 '086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47'
   end
 
   resource 'rspec-support' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.1'
+      tag: '1.6.2'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -110,8 +110,8 @@ class Soup < Formula
   end
 
   resource 'mcp' do
-    url 'https://rubygems.org/gems/mcp-0.7.1.gem'
-    sha256 'fa967895d6952bad0d981ea907731d8528d2c246d2079d56a9c8bae83d14f1c7'
+    url 'https://rubygems.org/gems/mcp-0.8.0.gem'
+    sha256 'ae8bd146bb8e168852866fd26f805f52744f6326afb3211e073f78a95e0c34fb'
   end
 
   resource 'mini_mime' do
@@ -231,8 +231,8 @@ class Soup < Formula
   end
 
   resource 'rspec-mocks' do
-    url 'https://rubygems.org/gems/rspec-mocks-3.13.7.gem'
-    sha256 '0979034e64b1d7a838aaaddf12bf065ea4dc40ef3d4c39f01f93ae2c66c62b1c'
+    url 'https://rubygems.org/gems/rspec-mocks-3.13.8.gem'
+    sha256 '086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47'
   end
 
   resource 'rspec-support' do


### PR DESCRIPTION
## Summary

Bump formula versions and update shared gem dependencies across all three Homebrew formulas.

**Key changes:**
- Bump citools from 1.5.1 to 1.5.2 in `citools.rb`
- Bump githubbuild from 1.12.1 to 1.13.0 in `githubbuild.rb`
- Bump soup from 1.6.1 to 1.6.2 in `soup.rb`
- Update mcp gem from 0.7.1 to 0.8.0 across all three formulas
- Update rspec-mocks gem from 3.13.7 to 3.13.8 across all three formulas

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bumps and dependency updates only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
