### PR TITLE
Bump citools 1.5.3, githubbuild 1.14.0, soup 1.6.3 and update dependencies

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.5.2'
+      tag: '1.5.3'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -239,8 +239,8 @@ class Citools < Formula
   end
 
   resource 'public_suffix' do
-    url 'https://rubygems.org/gems/public_suffix-7.0.2.gem'
-    sha256 '9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857'
+    url 'https://rubygems.org/gems/public_suffix-7.0.5.gem'
+    sha256 '1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623'
   end
 
   resource 'racc' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.13.0'
+      tag: '1.14.0'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -165,8 +165,8 @@ class Githubbuild < Formula
   end
 
   resource 'public_suffix' do
-    url 'https://rubygems.org/gems/public_suffix-7.0.2.gem'
-    sha256 '9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857'
+    url 'https://rubygems.org/gems/public_suffix-7.0.5.gem'
+    sha256 '1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623'
   end
 
   resource 'racc' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.2'
+      tag: '1.6.3'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -191,8 +191,8 @@ class Soup < Formula
   end
 
   resource 'public_suffix' do
-    url 'https://rubygems.org/gems/public_suffix-7.0.2.gem'
-    sha256 '9114090c8e4e7135c1fd0e7acfea33afaab38101884320c65aaa0ffb8e26a857'
+    url 'https://rubygems.org/gems/public_suffix-7.0.5.gem'
+    sha256 '1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623'
   end
 
   resource 'racc' do


### PR DESCRIPTION
## Summary

Bump formula versions and update shared dependencies.

**Key changes:**
- Update citools from 1.5.2 to 1.5.3
- Update githubbuild from 1.13.0 to 1.14.0
- Update soup from 1.6.2 to 1.6.3
- Update public_suffix dependency from 7.0.2 to 7.0.5 across all three formulas

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bumps and dependency updates only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
