### PR TITLE
Bump citools 1.6.1, githubbuild 1.16.1, soup 1.6.7 and update configs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 .github/                 @ydesgagn
 .gitignore               @ydesgagn
-.markdownlint.yml        @ydesgagn
+.markdownlint-cli2.yaml  @ydesgagn
 .rubocop.yml             @ydesgagn
 .ruby-version            @ydesgagn
 .shellcheckrc            @ydesgagn

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,25 @@
+globs:
+  - "**/*.md"
+  - "!.*"
+  - "!**/vendor/**"
+  - "!**/node_modules/**"
+  - "!**/Libraries/**"
+  - "!**/Pods/**"
+  - "!**/.build/**"
+  - "!**/Carthage/**"
+  - "!**/DerivedData/**"
+  - "!**/venv/**"
+  - "!**/.venv/**"
+  - "!**/dist/**"
+  - "!**/build/**"
+  - "!**/target/**"
+config:
+  default: true
+  first-line-heading: false
+  line-length: false
+  no-duplicate-heading: false
+  single-h1: false
+  tables: false
+  no-inline-html:
+    allowed_elements:
+      - br

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,9 +1,0 @@
-default: true
-first-line-heading: false
-line-length: false
-no-duplicate-heading: false
-single-h1: false
-tables: false
-no-inline-html:
-  allowed_elements:
-    - br

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -5,5 +5,20 @@ rules:
 ignore: |
   node_modules/
   vendor/
+  .build/
+  Pods/
+  Carthage/
+  DerivedData/
+  venv/
+  .venv/
+  .bundle/
+  .gradle/
+  .m2/
+  dist/
+  build/
+  target/
+  .npm/
+  .yarn/
+  .pnpm/
   tmp/
   var/

--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.6.0'
+      tag: '1.6.1'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -78,8 +78,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-iam' do
-    url 'https://rubygems.org/gems/aws-sdk-iam-1.140.0.gem'
-    sha256 '7a6990342f3c8c39812459949e31ca5c94ee8be8fd9a410c508c2bce767aff9e'
+    url 'https://rubygems.org/gems/aws-sdk-iam-1.141.0.gem'
+    sha256 '2cf899022394cc3dcf234cf08a0bb7360886b111636b5909f6565a0f3292b595'
   end
 
   resource 'aws-sdk-kms' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.16.0'
+      tag: '1.16.1'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.6'
+      tag: '1.6.7'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'


### PR DESCRIPTION
## Summary

Bump formula versions and update linter configuration files.

**Key changes:**
- Bump citools from 1.6.0 to 1.6.1 and update aws-sdk-iam dependency from 1.140.0 to 1.141.0
- Bump githubbuild from 1.16.0 to 1.16.1
- Bump soup from 1.6.6 to 1.6.7
- Migrate markdownlint config from `.markdownlint.yml` to `.markdownlint-cli2.yaml` with added glob patterns for file exclusions
- Add additional ignore paths to `.yamllint.yml` (build dirs, dependency caches, virtual envs)
- Update `.github/CODEOWNERS` to reference the new `.markdownlint-cli2.yaml` file

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bumps and config changes only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
