### PR TITLE
Bump githubbuild 1.17.1, soup 1.6.12 and improve update script

### DIFF
--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.17.0'
+      tag: '1.17.1'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -120,8 +120,8 @@ class Githubbuild < Formula
   end
 
   resource 'minitest' do
-    url 'https://rubygems.org/gems/minitest-6.0.2.gem'
-    sha256 'db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d'
+    url 'https://rubygems.org/gems/minitest-6.0.3.gem'
+    sha256 '88ac8a1de36c00692420e7cb3cc11a0773bbcb126aee1c249f320160a7d11411'
   end
 
   resource 'multi_xml' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.11'
+      tag: '1.6.12'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -110,8 +110,8 @@ class Soup < Formula
   end
 
   resource 'minitest' do
-    url 'https://rubygems.org/gems/minitest-6.0.2.gem'
-    sha256 'db6e57956f6ecc6134683b4c87467d6dd792323c7f0eea7b93f66bd284adbc3d'
+    url 'https://rubygems.org/gems/minitest-6.0.3.gem'
+    sha256 '88ac8a1de36c00692420e7cb3cc11a0773bbcb126aee1c249f320160a7d11411'
   end
 
   resource 'multi_xml' do

--- a/update_resources.sh
+++ b/update_resources.sh
@@ -137,6 +137,35 @@ for file in "${!files_to_dirs[@]}"; do
 
   echo "Current tag in ${file}: ${current_tag}"
 
+  # Navigate to the source repository for pre-flight checks
+  pushd "${cloud_officer_dir}/${directory}" >/dev/null
+
+  # Check for uncommitted changes in the source repository
+  if ! git diff-index --quiet HEAD --; then
+    echo "Warning: ${directory} has uncommitted changes. Please commit them first."
+    exit 1
+  fi
+
+  # Pull latest changes from remote
+  echo "Pulling latest changes in ${directory}..."
+  if ! git pull; then
+    echo "Warning: Failed to pull latest changes in ${directory}"
+    exit 1
+  fi
+
+  # Check for open pull requests
+  if ! open_prs=$(gh pr list --state open --json number --jq 'length' 2>&1); then
+    echo "Warning: Failed to check open pull requests in ${directory}: ${open_prs}"
+    exit 1
+  fi
+
+  if [ -n "${open_prs}" ] && [ "${open_prs}" -gt 0 ]; then
+    echo "Warning: ${directory} has ${open_prs} open pull request(s). Please close or merge them first."
+    exit 1
+  fi
+
+  popd >/dev/null
+
   # Check if source repo has new commits since the current tag
   source_repo_has_changes=false
   if has_commits_since_tag "${current_tag}" "${cloud_officer_dir}/${directory}"; then
@@ -194,35 +223,18 @@ for file in "${!files_to_dirs[@]}"; do
     # Navigate to the source repository
     pushd "${cloud_officer_dir}/${directory}" >/dev/null
 
-    # Check for uncommitted changes in the source repository
-    if ! git diff-index --quiet HEAD --; then
-      echo "Warning: ${directory} has uncommitted changes. Please commit them first."
-      exit 1
-    fi
-
-    # Pull latest changes from remote
-    echo "Pulling latest changes in ${directory}..."
-    if ! git pull; then
-      echo "Warning: Failed to pull latest changes in ${directory}"
-      exit 1
-    fi
-
-    # Check for open pull requests
-    open_prs=$(gh pr list --state open --json number --jq 'length')
-
-    if [ "${open_prs}" -gt 0 ]; then
-      echo "Warning: ${directory} has ${open_prs} open pull request(s). Please close or merge them first."
-      exit 1
-    fi
-
-    # Create the new tag
-    echo "Creating tag ${new_tag} in ${directory}..."
-    if git tag "${new_tag}"; then
-      git push origin "${new_tag}"
-      echo "Tag ${new_tag} created successfully"
+    # Create the new tag if it doesn't already exist
+    if git rev-parse "${new_tag}" >/dev/null 2>&1; then
+      echo "Tag ${new_tag} already exists in ${directory}, skipping tag creation"
     else
-      echo "Warning: Failed to create tag ${new_tag}"
-      exit 1
+      echo "Creating tag ${new_tag} in ${directory}..."
+      if git tag "${new_tag}"; then
+        git push origin "${new_tag}"
+        echo "Tag ${new_tag} created successfully"
+      else
+        echo "Warning: Failed to create tag ${new_tag}"
+        exit 1
+      fi
     fi
 
     popd >/dev/null


### PR DESCRIPTION
## Summary

Bump githubbuild to 1.17.1 and soup to 1.6.12, update the minitest dependency to 6.0.3, and improve the update_resources.sh script with earlier pre-flight checks and safer tag creation.

**Key changes:**
- Bump githubbuild tag from 1.17.0 to 1.17.1 and update minitest gem from 6.0.2 to 6.0.3
- Bump soup tag from 1.6.11 to 1.6.12 and update minitest gem from 6.0.2 to 6.0.3
- Move pre-flight checks (uncommitted changes, git pull, open PR detection) earlier in the update_resources.sh loop before determining if changes exist
- Add error handling for `gh pr list` command failure
- Skip tag creation if the tag already exists instead of failing

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [x] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bump and script improvement, no new testable logic
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
