### PR TITLE
Bump citools 1.7.0, githubbuild 1.18.0, soup 1.6.15 and update deps

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.6.5'
+      tag: '1.7.0'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -33,8 +33,8 @@ class Citools < Formula
   end
 
   resource 'aws-partitions' do
-    url 'https://rubygems.org/gems/aws-partitions-1.1235.0.gem'
-    sha256 '84eb9aec5c532c7c0aa008f5ebe4cac38488fa008da20aac1ae3e49eaf3f6240'
+    url 'https://rubygems.org/gems/aws-partitions-1.1237.0.gem'
+    sha256 '9b82f529b69ad83a8e4c5e123038924ed5e8f59bd6064a293ef20efc63364841'
   end
 
   resource 'aws-sdk-autoscaling' do
@@ -63,8 +63,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-ec2' do
-    url 'https://rubygems.org/gems/aws-sdk-ec2-1.610.0.gem'
-    sha256 'f73d949135910502bf81408a24e7ed6aaff78f66a05e24a1e9ac6ad0aec4b0f8'
+    url 'https://rubygems.org/gems/aws-sdk-ec2-1.611.0.gem'
+    sha256 'e6d713381e4057a46a8144f4aa582bb59dde55426f9675d3dabd3f9c3a1f9bfd'
   end
 
   resource 'aws-sdk-elasticloadbalancingv2' do
@@ -83,8 +83,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-lambda' do
-    url 'https://rubygems.org/gems/aws-sdk-lambda-1.176.0.gem'
-    sha256 '0562c2816dcb6dbca3c0d416b180ea71f296eb8034acd87a95d2ab9e1d00e545'
+    url 'https://rubygems.org/gems/aws-sdk-lambda-1.177.0.gem'
+    sha256 'fbbb672506b4df68a96ec08fa914a8ae818f3ec03e57d3d8176e0bc7f5b11b32'
   end
 
   resource 'aws-sdk-ssm' do
@@ -209,8 +209,8 @@ class Citools < Formula
   end
 
   resource 'parallel' do
-    url 'https://rubygems.org/gems/parallel-1.28.0.gem'
-    sha256 '33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970'
+    url 'https://rubygems.org/gems/parallel-2.0.0.gem'
+    sha256 '66c68ec5aac0827e742aa34458aa6af20c98e0f3d79f7735da700f3367471c95'
   end
 
   resource 'parser' do
@@ -264,8 +264,8 @@ class Citools < Formula
   end
 
   resource 'rubocop' do
-    url 'https://rubygems.org/gems/rubocop-1.86.0.gem'
-    sha256 '4ff1186fe16ebe9baff5e7aad66bb0ad4cabf5cdcd419f773146dbba2565d186'
+    url 'https://rubygems.org/gems/rubocop-1.86.1.gem'
+    sha256 '44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531'
   end
 
   resource 'rubocop-ast' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.17.3'
+      tag: '1.18.0'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -135,8 +135,8 @@ class Githubbuild < Formula
   end
 
   resource 'parallel' do
-    url 'https://rubygems.org/gems/parallel-1.28.0.gem'
-    sha256 '33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970'
+    url 'https://rubygems.org/gems/parallel-2.0.0.gem'
+    sha256 '66c68ec5aac0827e742aa34458aa6af20c98e0f3d79f7735da700f3367471c95'
   end
 
   resource 'parser' do
@@ -205,8 +205,8 @@ class Githubbuild < Formula
   end
 
   resource 'rubocop' do
-    url 'https://rubygems.org/gems/rubocop-1.86.0.gem'
-    sha256 '4ff1186fe16ebe9baff5e7aad66bb0ad4cabf5cdcd419f773146dbba2565d186'
+    url 'https://rubygems.org/gems/rubocop-1.86.1.gem'
+    sha256 '44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531'
   end
 
   resource 'rubocop-ast' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.14'
+      tag: '1.6.15'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -161,8 +161,8 @@ class Soup < Formula
   end
 
   resource 'parallel' do
-    url 'https://rubygems.org/gems/parallel-1.28.0.gem'
-    sha256 '33e6de1484baf2524792d178b0913fc8eb94c628d6cfe45599ad4458c638c970'
+    url 'https://rubygems.org/gems/parallel-2.0.0.gem'
+    sha256 '66c68ec5aac0827e742aa34458aa6af20c98e0f3d79f7735da700f3367471c95'
   end
 
   resource 'parser' do
@@ -231,8 +231,8 @@ class Soup < Formula
   end
 
   resource 'rubocop' do
-    url 'https://rubygems.org/gems/rubocop-1.86.0.gem'
-    sha256 '4ff1186fe16ebe9baff5e7aad66bb0ad4cabf5cdcd419f773146dbba2565d186'
+    url 'https://rubygems.org/gems/rubocop-1.86.1.gem'
+    sha256 '44415f3f01d01a21e01132248d2fd0867572475b566ca188a0a42133a08d4531'
   end
 
   resource 'rubocop-ast' do


### PR DESCRIPTION
# Summary

Bump formula versions and update shared dependencies.

**Key changes:**
- Bump citools from 1.6.5 to 1.7.0 with updated AWS SDK gems (aws-partitions 1.1237.0, aws-sdk-ec2 1.611.0, aws-sdk-lambda 1.177.0)
- Bump githubbuild from 1.17.3 to 1.18.0
- Bump soup from 1.6.14 to 1.6.15
- Update parallel gem from 1.28.0 to 2.0.0 across all three formulas
- Update rubocop gem from 1.86.0 to 1.86.1 across all three formulas

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency version bump only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
