### PR TITLE
Bump citools 1.7.1, githubbuild 1.18.1, soup 1.6.16 and update deps

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.0'
+      tag: '1.7.1'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -209,8 +209,8 @@ class Citools < Formula
   end
 
   resource 'parallel' do
-    url 'https://rubygems.org/gems/parallel-2.0.0.gem'
-    sha256 '66c68ec5aac0827e742aa34458aa6af20c98e0f3d79f7735da700f3367471c95'
+    url 'https://rubygems.org/gems/parallel-2.0.1.gem'
+    sha256 '337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d'
   end
 
   resource 'parser' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.18.0'
+      tag: '1.18.1'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -135,8 +135,8 @@ class Githubbuild < Formula
   end
 
   resource 'parallel' do
-    url 'https://rubygems.org/gems/parallel-2.0.0.gem'
-    sha256 '66c68ec5aac0827e742aa34458aa6af20c98e0f3d79f7735da700f3367471c95'
+    url 'https://rubygems.org/gems/parallel-2.0.1.gem'
+    sha256 '337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d'
   end
 
   resource 'parser' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.15'
+      tag: '1.6.16'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -161,8 +161,8 @@ class Soup < Formula
   end
 
   resource 'parallel' do
-    url 'https://rubygems.org/gems/parallel-2.0.0.gem'
-    sha256 '66c68ec5aac0827e742aa34458aa6af20c98e0f3d79f7735da700f3367471c95'
+    url 'https://rubygems.org/gems/parallel-2.0.1.gem'
+    sha256 '337782d3e39f4121e67563bf91dd8ece67f48923d90698614773a0ec9a5b2c7d'
   end
 
   resource 'parser' do


### PR DESCRIPTION
# Summary

Bump formula versions and update shared dependency.

**Key changes:**
- Bump citools from 1.7.0 to 1.7.1
- Bump githubbuild from 1.18.0 to 1.18.1
- Bump soup from 1.6.15 to 1.6.16
- Update parallel gem from 2.0.0 to 2.0.1 across all three formulas

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Version bump and dependency update only
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
