### PR TITLE
Bump citools 1.7.6, githubbuild 1.19.1, soup 1.6.19 and update deps

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.5'
+      tag: '1.7.6'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -103,8 +103,8 @@ class Citools < Formula
   end
 
   resource 'bigdecimal' do
-    url 'https://rubygems.org/gems/bigdecimal-4.1.1.gem'
-    sha256 '1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca'
+    url 'https://rubygems.org/gems/bigdecimal-4.1.2.gem'
+    sha256 '53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd'
   end
 
   resource 'csv' do
@@ -138,8 +138,8 @@ class Citools < Formula
   end
 
   resource 'json' do
-    url 'https://rubygems.org/gems/json-2.19.3.gem'
-    sha256 '289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646'
+    url 'https://rubygems.org/gems/json-2.19.4.gem'
+    sha256 '670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac'
   end
 
   resource 'language_server-protocol' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.19.0'
+      tag: '1.19.1'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -30,8 +30,8 @@ class Githubbuild < Formula
   end
 
   resource 'bigdecimal' do
-    url 'https://rubygems.org/gems/bigdecimal-4.1.1.gem'
-    sha256 '1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca'
+    url 'https://rubygems.org/gems/bigdecimal-4.1.2.gem'
+    sha256 '53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd'
   end
 
   resource 'concurrent-ruby' do
@@ -95,8 +95,8 @@ class Githubbuild < Formula
   end
 
   resource 'json' do
-    url 'https://rubygems.org/gems/json-2.19.3.gem'
-    sha256 '289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646'
+    url 'https://rubygems.org/gems/json-2.19.4.gem'
+    sha256 '670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac'
   end
 
   resource 'language_server-protocol' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.18'
+      tag: '1.6.19'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -30,8 +30,8 @@ class Soup < Formula
   end
 
   resource 'bigdecimal' do
-    url 'https://rubygems.org/gems/bigdecimal-4.1.1.gem'
-    sha256 '1c09efab961da45203c8316b0cdaec0ff391dfadb952dd459584b63ebf8054ca'
+    url 'https://rubygems.org/gems/bigdecimal-4.1.2.gem'
+    sha256 '53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd'
   end
 
   resource 'concurrent-ruby' do
@@ -85,8 +85,8 @@ class Soup < Formula
   end
 
   resource 'json' do
-    url 'https://rubygems.org/gems/json-2.19.3.gem'
-    sha256 '289b0bb53052a1fa8c34ab33cc750b659ba14a5c45f3fcf4b18762dc67c78646'
+    url 'https://rubygems.org/gems/json-2.19.4.gem'
+    sha256 '670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac'
   end
 
   resource 'language_server-protocol' do


### PR DESCRIPTION
## Summary

Bumps three formulas to their latest versions and refreshes shared Ruby gem dependencies used by each.

**Key changes:**

- Bump `citools` to 1.7.6
- Bump `githubbuild` to 1.19.1
- Bump `soup` to 1.6.19
- Update `bigdecimal` gem from 4.1.1 to 4.1.2 across all three formulas
- Update `json` gem from 2.19.3 to 2.19.4 across all three formulas

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
