### PR TITLE
Bump citools 1.7.8, githubbuild 1.20.1, soup 1.6.21 and update deps

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -77,10 +77,3 @@ jobs:
       env:
         GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
         PR: "${{github.event.pull_request.number}}"
-    - name: Enable auto-merge
-      shell: bash
-      if: steps.check.outputs.is_owner == 'true'
-      run: gh pr merge --auto --squash "$PR"
-      env:
-        GH_TOKEN: "${{secrets.GITHUB_TOKEN}}"
-        PR: "${{github.event.pull_request.number}}"

--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.7'
+      tag: '1.7.8'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -53,8 +53,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-cloudwatchlogs' do
-    url 'https://rubygems.org/gems/aws-sdk-cloudwatchlogs-1.146.0.gem'
-    sha256 '546bc39964dd4e336370dbeaf7b7ef87ae6d320bc1a1675c6db16d70d13ac646'
+    url 'https://rubygems.org/gems/aws-sdk-cloudwatchlogs-1.147.0.gem'
+    sha256 '0120f4fbbda6d2fdebd8ead45526beeb57a3f1fa5d0e23872afab897df16dc05'
   end
 
   resource 'aws-sdk-core' do
@@ -78,8 +78,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-kms' do
-    url 'https://rubygems.org/gems/aws-sdk-kms-1.123.0.gem'
-    sha256 'd405f37e82f8fa32045ca8980be266c0b45b37aaf2012afe0254321a1e811f20'
+    url 'https://rubygems.org/gems/aws-sdk-kms-1.124.0.gem'
+    sha256 '40d00ab706d7e49fd620270bd0dcb546f266295abdd49b54fec2611e2a41f37c'
   end
 
   resource 'aws-sdk-lambda' do
@@ -170,8 +170,8 @@ class Citools < Formula
   on_linux do
     on_arm do
       resource 'nokogiri' do
-        url 'https://rubygems.org/gems/nokogiri-1.19.2-aarch64-linux-gnu.gem'
-        sha256 'c34d5c8208025587554608e98fd88ab125b29c80f9352b821964e9a5d5cfbd19'
+        url 'https://rubygems.org/gems/nokogiri-1.19.3-aarch64-linux-gnu.gem'
+        sha256 '46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639'
       end
     end
   end
@@ -179,8 +179,8 @@ class Citools < Formula
   on_macos do
     on_arm do
       resource 'nokogiri' do
-        url 'https://rubygems.org/gems/nokogiri-1.19.2-arm64-darwin.gem'
-        sha256 '58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205'
+        url 'https://rubygems.org/gems/nokogiri-1.19.3-arm64-darwin.gem'
+        sha256 '71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42'
       end
     end
   end
@@ -188,8 +188,8 @@ class Citools < Formula
   on_macos do
     on_intel do
       resource 'nokogiri' do
-        url 'https://rubygems.org/gems/nokogiri-1.19.2-x86_64-darwin.gem'
-        sha256 '7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4'
+        url 'https://rubygems.org/gems/nokogiri-1.19.3-x86_64-darwin.gem'
+        sha256 '77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d'
       end
     end
   end
@@ -197,8 +197,8 @@ class Citools < Formula
   on_linux do
     on_intel do
       resource 'nokogiri' do
-        url 'https://rubygems.org/gems/nokogiri-1.19.2-x86_64-linux-gnu.gem'
-        sha256 'fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f'
+        url 'https://rubygems.org/gems/nokogiri-1.19.3-x86_64-linux-gnu.gem'
+        sha256 '2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976'
       end
     end
   end

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.20.0'
+      tag: '1.20.1'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.20'
+      tag: '1.6.21'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -122,8 +122,8 @@ class Soup < Formula
   on_linux do
     on_arm do
       resource 'nokogiri' do
-        url 'https://rubygems.org/gems/nokogiri-1.19.2-aarch64-linux-gnu.gem'
-        sha256 'c34d5c8208025587554608e98fd88ab125b29c80f9352b821964e9a5d5cfbd19'
+        url 'https://rubygems.org/gems/nokogiri-1.19.3-aarch64-linux-gnu.gem'
+        sha256 '46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639'
       end
     end
   end
@@ -131,8 +131,8 @@ class Soup < Formula
   on_macos do
     on_arm do
       resource 'nokogiri' do
-        url 'https://rubygems.org/gems/nokogiri-1.19.2-arm64-darwin.gem'
-        sha256 '58d8ea2e31a967b843b70487a44c14c8ba1866daa1b9da9be9dbdf1b43dee205'
+        url 'https://rubygems.org/gems/nokogiri-1.19.3-arm64-darwin.gem'
+        sha256 '71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42'
       end
     end
   end
@@ -140,8 +140,8 @@ class Soup < Formula
   on_macos do
     on_intel do
       resource 'nokogiri' do
-        url 'https://rubygems.org/gems/nokogiri-1.19.2-x86_64-darwin.gem'
-        sha256 '7d9af11fda72dfaa2961d8c4d5380ca0b51bc389dc5f8d4b859b9644f195e7a4'
+        url 'https://rubygems.org/gems/nokogiri-1.19.3-x86_64-darwin.gem'
+        sha256 '77f3fba57d46c53ab31e62fc6c28f705109d1bf6264356c76f132b2be5728d4d'
       end
     end
   end
@@ -149,8 +149,8 @@ class Soup < Formula
   on_linux do
     on_intel do
       resource 'nokogiri' do
-        url 'https://rubygems.org/gems/nokogiri-1.19.2-x86_64-linux-gnu.gem'
-        sha256 'fa8feca882b73e871a9845f3817a72e9734c8e974bdc4fbad6e4bc6e8076b94f'
+        url 'https://rubygems.org/gems/nokogiri-1.19.3-x86_64-linux-gnu.gem'
+        sha256 '2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976'
       end
     end
   end


### PR DESCRIPTION
## Summary

Updates Homebrew formulae to the latest tool versions and refreshes their bundled gem dependencies. Also removes the auto-merge step from the auto-merge workflow.

**Key changes:**

- Bump `citools` formula from 1.7.7 to 1.7.8
- Bump `githubbuild` formula from 1.20.0 to 1.20.1
- Bump `soup` formula from 1.6.20 to 1.6.21
- Update `aws-sdk-cloudwatchlogs` from 1.146.0 to 1.147.0 in citools
- Update `aws-sdk-kms` from 1.123.0 to 1.124.0 in citools
- Update `nokogiri` from 1.19.2 to 1.19.3 across all platforms in citools and soup
- Remove the "Enable auto-merge" step from `.github/workflows/auto-merge.yml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency version bumps for Homebrew formulae; verified by formula install.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
