### PR TITLE
Bump citools 1.7.9, githubbuild 1.21.0, soup 1.6.22 and update deps

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.8'
+      tag: '1.7.9'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -33,8 +33,8 @@ class Citools < Formula
   end
 
   resource 'aws-partitions' do
-    url 'https://rubygems.org/gems/aws-partitions-1.1241.0.gem'
-    sha256 'cd0efc435de2782e8bdc77ae76bdafe70f493d54398071a88dbb1e1d32026cbe'
+    url 'https://rubygems.org/gems/aws-partitions-1.1243.0.gem'
+    sha256 '2751071202381b7bb115a1f592d699c73bb5ac9ad4e5aece6a14b1dabc265c43'
   end
 
   resource 'aws-sdk-autoscaling' do
@@ -48,8 +48,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-cloudfront' do
-    url 'https://rubygems.org/gems/aws-sdk-cloudfront-1.143.0.gem'
-    sha256 '2a5bd39a6d849dbe793ffb20db909aee1bbe7692f8d0a44435e46b32ca7382fb'
+    url 'https://rubygems.org/gems/aws-sdk-cloudfront-1.144.0.gem'
+    sha256 '472b94c5b6699dab4dbfaf7e8c985211958b4d736e8b874d5be7a09a533d8475'
   end
 
   resource 'aws-sdk-cloudwatchlogs' do
@@ -274,8 +274,8 @@ class Citools < Formula
   end
 
   resource 'rubocop-capybara' do
-    url 'https://rubygems.org/gems/rubocop-capybara-2.22.1.gem'
-    sha256 'ced88caef23efea53f46e098ff352f8fc1068c649606ca75cb74650970f51c0c'
+    url 'https://rubygems.org/gems/rubocop-capybara-2.23.0.gem'
+    sha256 'f9ea1ba3a7561ee8e88cf76fc378ce517ce5327155f305ee7b5c2500e5aee357'
   end
 
   resource 'rubocop-graphql' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.20.1'
+      tag: '1.21.0'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -215,8 +215,8 @@ class Githubbuild < Formula
   end
 
   resource 'rubocop-capybara' do
-    url 'https://rubygems.org/gems/rubocop-capybara-2.22.1.gem'
-    sha256 'ced88caef23efea53f46e098ff352f8fc1068c649606ca75cb74650970f51c0c'
+    url 'https://rubygems.org/gems/rubocop-capybara-2.23.0.gem'
+    sha256 'f9ea1ba3a7561ee8e88cf76fc378ce517ce5327155f305ee7b5c2500e5aee357'
   end
 
   resource 'rubocop-graphql' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.6.21'
+      tag: '1.6.22'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -241,8 +241,8 @@ class Soup < Formula
   end
 
   resource 'rubocop-capybara' do
-    url 'https://rubygems.org/gems/rubocop-capybara-2.22.1.gem'
-    sha256 'ced88caef23efea53f46e098ff352f8fc1068c649606ca75cb74650970f51c0c'
+    url 'https://rubygems.org/gems/rubocop-capybara-2.23.0.gem'
+    sha256 'f9ea1ba3a7561ee8e88cf76fc378ce517ce5327155f305ee7b5c2500e5aee357'
   end
 
   resource 'rubocop-graphql' do


### PR DESCRIPTION
## Summary

Routine formula version bumps for the three Cloud-Officer Homebrew formulas, along with refreshed shared resource dependencies.

**Key changes:**
- Bump `citools` from 1.7.8 to 1.7.9 (`citools.rb`)
- Bump `githubbuild` from 1.20.1 to 1.21.0 (`githubbuild.rb`)
- Bump `soup` from 1.6.21 to 1.6.22 (`soup.rb`)
- Update `aws-partitions` to 1.1243.0 and `aws-sdk-cloudfront` to 1.144.0 in `citools.rb`
- Update `rubocop-capybara` to 2.23.0 across `citools.rb`, `githubbuild.rb`, and `soup.rb`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] ``readme.md`` includes sections on introduction, installation, usage, and contributing
- [ ] ``docs/architecture.md`` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified