### PR TITLE
Bump citools 1.7.15, githubbuild 1.21.6, soup 1.7.3 and checkout@v6

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: "${{github.event.pull_request.base.sha}}"
     - name: Check if PR author is a code owner

--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.14'
+      tag: '1.7.15'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -88,8 +88,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-ssm' do
-    url 'https://rubygems.org/gems/aws-sdk-ssm-1.212.0.gem'
-    sha256 '89137ce784f8e329d14672a1c4d7e8ca0cbe8082bb3120a4af87c71ffe0e7bda'
+    url 'https://rubygems.org/gems/aws-sdk-ssm-1.213.0.gem'
+    sha256 '6ec7d7ea8ae9608d72244b23d87369f7129a4d2e59f038227ceaebccf8b28f47'
   end
 
   resource 'aws-sigv4' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.21.5'
+      tag: '1.21.6'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.7.2'
+      tag: '1.7.3'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'


### PR DESCRIPTION
## Summary

Routine dependency bump for the Homebrew formulas, plus a CI workflow update to the latest `actions/checkout` major version.

**Key changes:**

- Bump `citools` formula from 1.7.14 to 1.7.15 and update the `aws-sdk-ssm` resource from 1.212.0 to 1.213.0
- Bump `githubbuild` formula from 1.21.5 to 1.21.6
- Bump `soup` formula from 1.7.2 to 1.7.3
- Update `actions/checkout` from `v4` to `v6` in `.github/workflows/auto-merge.yml`

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [ ] I did not add automation test. Why ?:
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified