### PR TITLE
Bump citools 1.7.19, githubbuild 1.24.0, soup 1.9.2 and guard self-approval

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -75,7 +75,17 @@ jobs:
     - name: Approve PR
       shell: bash
       if: steps.check.outputs.is_owner == 'true'
-      run: gh pr review --approve "$PR"
+      run: |
+        set -euo pipefail
+
+        APPROVER=$(gh api user --jq .login)
+        if [ "$APPROVER" = "$AUTHOR" ]; then
+          echo "Approver $APPROVER is the PR author; skipping self-approval."
+          exit 0
+        fi
+
+        gh pr review --approve "$PR"
       env:
         GH_TOKEN: "${{secrets.GH_BOT_PAT}}"
+        AUTHOR: "${{github.event.pull_request.user.login}}"
         PR: "${{github.event.pull_request.number}}"

--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.18'
+      tag: '1.7.19'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.23.1'
+      tag: '1.24.0'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.9.1'
+      tag: '1.9.2'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'


### PR DESCRIPTION
## Summary

Updates the pinned tags for three Homebrew formulae to their latest releases and hardens the auto-approve workflow so it no longer attempts to approve a PR opened by its own bot account.

**Key changes:**

- Bump `citools` formula tag from `1.7.18` to `1.7.19`.
- Bump `githubbuild` formula tag from `1.23.1` to `1.24.0`.
- Bump `soup` formula tag from `1.9.1` to `1.9.2`.
- Add a self-approval guard to `.github/workflows/auto-approve.yml`: the Approve step now compares the authenticated approver against the PR author and skips approval when they match, avoiding GitHub's "cannot approve your own pull request" failure.

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: These are Homebrew formula version bumps and a CI workflow guard; the repo has no automated test suite for them.
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified