### PR TITLE
Move citools Ruby scripts to libexec so require_relative resolves

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -364,10 +364,14 @@ class Citools < Formula
   end
 
   def install
-    bin.install('brew-resources.rb')
-    bin.install('cycle-keys.rb')
-    bin.install('deploy.rb')
-    bin.install('encrypt-logs.rb')
+    # Ruby scripts that `require_relative 'lib/cli_main'` live in libexec next
+    # to the lib/ directory so the relative require resolves; bin only gets the
+    # bash wrappers below. Standalone tools with no lib/ dependency stay in bin.
+    libexec.install('brew-resources.rb')
+    libexec.install('cycle-keys.rb')
+    libexec.install('deploy.rb')
+    libexec.install('encrypt-logs.rb')
+    libexec.install('lib')
     bin.install('generate-codeowners')
     bin.install('linters')
     bin.install('ssm-jump')
@@ -393,7 +397,7 @@ class Citools < Formula
       export GEM_HOME="#{libexec}/vendor"
       export GEM_PATH="#{libexec}/vendor"
       export DISABLE_BUNDLER_SETUP=1
-      exec "#{Formula['ruby'].opt_bin}/ruby" "#{bin}/brew-resources.rb" "$@"
+      exec "#{Formula['ruby'].opt_bin}/ruby" "#{libexec}/brew-resources.rb" "$@"
     SHELL
   end
 
@@ -403,7 +407,7 @@ class Citools < Formula
       export GEM_HOME="#{libexec}/vendor"
       export GEM_PATH="#{libexec}/vendor"
       export DISABLE_BUNDLER_SETUP=1
-      exec "#{Formula['ruby'].opt_bin}/ruby" "#{bin}/cycle-keys.rb" "$@"
+      exec "#{Formula['ruby'].opt_bin}/ruby" "#{libexec}/cycle-keys.rb" "$@"
     SHELL
   end
 
@@ -413,7 +417,7 @@ class Citools < Formula
       export GEM_HOME="#{libexec}/vendor"
       export GEM_PATH="#{libexec}/vendor"
       export DISABLE_BUNDLER_SETUP=1
-      exec "#{Formula['ruby'].opt_bin}/ruby" "#{bin}/deploy.rb" "$@"
+      exec "#{Formula['ruby'].opt_bin}/ruby" "#{libexec}/deploy.rb" "$@"
     SHELL
   end
 
@@ -423,7 +427,7 @@ class Citools < Formula
       export GEM_HOME="#{libexec}/vendor"
       export GEM_PATH="#{libexec}/vendor"
       export DISABLE_BUNDLER_SETUP=1
-      exec "#{Formula['ruby'].opt_bin}/ruby" "#{bin}/encrypt-logs.rb" "$@"
+      exec "#{Formula['ruby'].opt_bin}/ruby" "#{libexec}/encrypt-logs.rb" "$@"
     SHELL
   end
 end


### PR DESCRIPTION
## Summary

The `citools` formula installed `brew-resources.rb`, `cycle-keys.rb`, `deploy.rb`, and `encrypt-logs.rb` directly into `bin`, but these scripts `require_relative 'lib/...'`. Because the `lib/` directory was not installed alongside them, the relative require could not resolve at runtime. This moves those scripts into `libexec` next to the `lib/` directory and points the bash wrappers at the new location, so the require resolves while `bin` keeps only the wrappers.

**Key changes:**

- Install `brew-resources.rb`, `cycle-keys.rb`, `deploy.rb`, and `encrypt-logs.rb` into `libexec` instead of `bin`
- Install the `lib` directory into `libexec` so `require_relative 'lib/...'` resolves
- Update the `brew-resources`, `cycle-keys`, `deploy`, and `encrypt-logs` bash wrappers to exec the scripts from `libexec`
- Add a comment documenting why scripts with a `lib/` dependency live in `libexec` while standalone tools stay in `bin`

## Types of changes

- [x] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [ ] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Homebrew formula packaging change, validated via brew install/audit
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified