### PR TITLE
Bump citools 1.7.25, githubbuild 1.24.6, soup 1.9.7 and update gem resources

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.24'
+      tag: '1.7.25'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -38,8 +38,8 @@ class Citools < Formula
   end
 
   resource 'aws-partitions' do
-    url 'https://rubygems.org/gems/aws-partitions-1.1257.0.gem'
-    sha256 '03c531f40fdd979a9ae2aae70140c60e59000e6f62a60b3d6171b78cdded960c'
+    url 'https://rubygems.org/gems/aws-partitions-1.1258.0.gem'
+    sha256 '3fee017570594ecf5e7f4c845b115fef8000530e57bdaf2b927357e5bf08967f'
   end
 
   resource 'aws-sdk-autoscaling' do
@@ -319,8 +319,8 @@ class Citools < Formula
   end
 
   resource 'rubocop-rspec' do
-    url 'https://rubygems.org/gems/rubocop-rspec-3.9.0.gem'
-    sha256 '8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2'
+    url 'https://rubygems.org/gems/rubocop-rspec-3.10.2.gem'
+    sha256 '0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2'
   end
 
   resource 'rubocop-thread_safety' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.24.5'
+      tag: '1.24.6'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -235,8 +235,8 @@ class Githubbuild < Formula
   end
 
   resource 'rubocop-rspec' do
-    url 'https://rubygems.org/gems/rubocop-rspec-3.9.0.gem'
-    sha256 '8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2'
+    url 'https://rubygems.org/gems/rubocop-rspec-3.10.2.gem'
+    sha256 '0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2'
   end
 
   resource 'rubocop-thread_safety' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.9.6'
+      tag: '1.9.7'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -261,8 +261,8 @@ class Soup < Formula
   end
 
   resource 'rubocop-rspec' do
-    url 'https://rubygems.org/gems/rubocop-rspec-3.9.0.gem'
-    sha256 '8fa70a3619408237d789aeecfb9beef40576acc855173e60939d63332fdb55e2'
+    url 'https://rubygems.org/gems/rubocop-rspec-3.10.2.gem'
+    sha256 '0b3e2ecc592cd10ecbf0095bb58d1e357905276e069643523cc19eb7495f65e2'
   end
 
   resource 'rubocop-thread_safety' do


### PR DESCRIPTION
## Summary

Routine version bump of the three Cloud-Officer Homebrew formulae and refresh of their pinned gem resources.

**Key changes:**

- Bump `citools` formula tag `1.7.24` → `1.7.25`
- Bump `githubbuild` formula tag `1.24.5` → `1.24.6`
- Bump `soup` formula tag `1.9.6` → `1.9.7`
- Update `aws-partitions` gem resource `1.1257.0` → `1.1258.0` (citools)
- Update `rubocop-rspec` gem resource `3.9.0` → `3.10.2` (citools, githubbuild, soup)

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Homebrew formula version/resource bump; validated by CI brew audit/install
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified