### PR TITLE
Bump githubbuild 1.24.8, soup 1.9.10 and update i18n gem resource

### DIFF
--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.24.7'
+      tag: '1.24.8'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -90,8 +90,8 @@ class Githubbuild < Formula
   end
 
   resource 'i18n' do
-    url 'https://rubygems.org/gems/i18n-1.15.0.gem'
-    sha256 'ed20037ed7ca75dd36ec486b5fb9696e8e0cfe48f4f80980017932d93e70527f'
+    url 'https://rubygems.org/gems/i18n-1.15.1.gem'
+    sha256 '505ec5de1f4e6c8a2cb028ef9700ca495f117911643455721dee5abdca797255'
   end
 
   resource 'json' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.9.9'
+      tag: '1.9.10'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -80,8 +80,8 @@ class Soup < Formula
   end
 
   resource 'i18n' do
-    url 'https://rubygems.org/gems/i18n-1.15.0.gem'
-    sha256 'ed20037ed7ca75dd36ec486b5fb9696e8e0cfe48f4f80980017932d93e70527f'
+    url 'https://rubygems.org/gems/i18n-1.15.1.gem'
+    sha256 '505ec5de1f4e6c8a2cb028ef9700ca495f117911643455721dee5abdca797255'
   end
 
   resource 'json' do


### PR DESCRIPTION
## Summary

Updates the Homebrew formulae to the latest upstream releases and refreshes the bundled gem resources accordingly.

**Key changes:**

- Bump `githubbuild` formula tag from 1.24.7 to 1.24.8
- Bump `soup` formula tag from 1.9.9 to 1.9.10
- Update the `i18n` gem resource from 1.15.0 to 1.15.1 (URL and sha256) in both formulae

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency/version bump of Homebrew formulae
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified
