### PR TITLE
Bump citools 1.7.28, githubbuild 1.24.11, soup 1.9.12 and update gem resources

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@v7
       with:
         ref: "${{github.event.pull_request.base.sha}}"
     - name: Check if PR author is a code owner

--- a/README.md
+++ b/README.md
@@ -46,10 +46,6 @@ brew list --versions cloud-officer/ci/<formula>
 
 This formula installs the following tools:
 
-* brew-resources (check for gem dependencies and generate brew resources section for formulae)
-* cycle-keys (rotate AWS keys)
-* deploy (automate the ASG, spot fleet and Lambda deployments)
-* encrypt-logs (encrypt logs in AWS CloudWatch Logs)
 * generate-codeowners (generate codeowners file)
 * linters (run all linters)
 * ssm-jump (ssh to a host by name without VPN)

--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.27'
+      tag: '1.7.28'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.24.10'
+      tag: '1.24.11'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -90,8 +90,8 @@ class Githubbuild < Formula
   end
 
   resource 'i18n' do
-    url 'https://rubygems.org/gems/i18n-1.15.1.gem'
-    sha256 '505ec5de1f4e6c8a2cb028ef9700ca495f117911643455721dee5abdca797255'
+    url 'https://rubygems.org/gems/i18n-1.15.2.gem'
+    sha256 '00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5'
   end
 
   resource 'json' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.9.11'
+      tag: '1.9.12'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -80,8 +80,8 @@ class Soup < Formula
   end
 
   resource 'i18n' do
-    url 'https://rubygems.org/gems/i18n-1.15.1.gem'
-    sha256 '505ec5de1f4e6c8a2cb028ef9700ca495f117911643455721dee5abdca797255'
+    url 'https://rubygems.org/gems/i18n-1.15.2.gem'
+    sha256 '00f9eb62412fe593b2a65a97daa75300d37abb8f7202ec748e94b6d46a9dd1b5'
   end
 
   resource 'json' do


### PR DESCRIPTION
## Summary

Routine dependency bump of the tap formulae to their latest upstream releases, refreshes the bundled gem resources, updates the auto-approve workflow action, and trims removed tools from the README.

**Key changes:**

- Bump `citools` formula to tag `1.7.28`
- Bump `githubbuild` formula to tag `1.24.11`
- Bump `soup` formula to tag `1.9.12`
- Update the `i18n` gem resource to `1.15.2` in `githubbuild.rb` and `soup.rb`
- Upgrade `actions/checkout` from `v6` to `v7` in the auto-approve workflow
- Remove `brew-resources`, `cycle-keys`, `deploy`, and `encrypt-logs` from the README tool list

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [x] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [ ] I have manually tested my change
- [x] I did not add automation test. Why ?: Dependency version bumps validated by the tap's brew build CI
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified