### PR TITLE
Bump citools 1.7.31, githubbuild 1.24.17, soup 1.9.16 and gem resources

### DIFF
--- a/citools.rb
+++ b/citools.rb
@@ -4,7 +4,7 @@ class Citools < Formula
   desc 'Continuous Integration tools'
   homepage 'https://github.com/Cloud-Officer/ci-tools'
   url 'https://github.com/Cloud-Officer/ci-tools.git',
-      tag: '1.7.30'
+      tag: '1.7.31'
   head 'https://github.com/Cloud-Officer/ci-tools.git'
 
   depends_on 'actionlint'
@@ -38,18 +38,18 @@ class Citools < Formula
   end
 
   resource 'aws-partitions' do
-    url 'https://rubygems.org/gems/aws-partitions-1.1262.0.gem'
-    sha256 '77e9b1dd3e8f616673f2959d2fc4e762065f83a43140e2cb82274525afbaccf7'
+    url 'https://rubygems.org/gems/aws-partitions-1.1265.0.gem'
+    sha256 '591a4e4ba0bfde0a37fcfed1b0f57c8915c44d0564c4c332606bc9926d6f65d1'
   end
 
   resource 'aws-sdk-autoscaling' do
-    url 'https://rubygems.org/gems/aws-sdk-autoscaling-1.161.0.gem'
-    sha256 '257447d1d4928d2b224f6eb9163cd264ae38435e1f4796cb0a05d5e32275fadc'
+    url 'https://rubygems.org/gems/aws-sdk-autoscaling-1.162.0.gem'
+    sha256 'dc718aa527d0f752cab54d79286bd086c72fdf79c05657c2ccd2085ff5a62ad6'
   end
 
   resource 'aws-sdk-cloudformation' do
-    url 'https://rubygems.org/gems/aws-sdk-cloudformation-1.154.0.gem'
-    sha256 '2cf4cf05ce5f7fa5f7a7105efa0e3d026ff8d31a2abb90eec6af3fdb04682cf2'
+    url 'https://rubygems.org/gems/aws-sdk-cloudformation-1.155.0.gem'
+    sha256 '34f0de2161825bbaea45d901b254d154c8c51bdb6a02dada259e34673be2f43a'
   end
 
   resource 'aws-sdk-cloudfront' do
@@ -68,8 +68,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-ec2' do
-    url 'https://rubygems.org/gems/aws-sdk-ec2-1.625.0.gem'
-    sha256 '4af293c8d1b5398bc3b8b68b48c6e9f63c5ae898bd2bfc56acb7842b3ea3c7e7'
+    url 'https://rubygems.org/gems/aws-sdk-ec2-1.628.0.gem'
+    sha256 '06fcc115f1155fec27ffe4f9ee253fa901ff12dcba4e0655625403c9f4b066f6'
   end
 
   resource 'aws-sdk-elasticloadbalancingv2' do
@@ -88,8 +88,8 @@ class Citools < Formula
   end
 
   resource 'aws-sdk-lambda' do
-    url 'https://rubygems.org/gems/aws-sdk-lambda-1.185.0.gem'
-    sha256 'ba0e6f083776ff7c3538999bff85e18458c1c182d82538453b84277efc27c50e'
+    url 'https://rubygems.org/gems/aws-sdk-lambda-1.186.0.gem'
+    sha256 '5afaeeb4de376700cf7391bc59fad7514b8a0ac119fbd0157c5ee325d7a26a86'
   end
 
   resource 'aws-sdk-ssm' do
@@ -158,8 +158,8 @@ class Citools < Formula
   end
 
   resource 'language_server-protocol' do
-    url 'https://rubygems.org/gems/language_server-protocol-3.17.0.5.gem'
-    sha256 'fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc'
+    url 'https://rubygems.org/gems/language_server-protocol-3.17.0.6.gem'
+    sha256 '5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0'
   end
 
   resource 'lint_roller' do
@@ -289,8 +289,8 @@ class Citools < Formula
   end
 
   resource 'rubocop' do
-    url 'https://rubygems.org/gems/rubocop-1.88.0.gem'
-    sha256 'e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b'
+    url 'https://rubygems.org/gems/rubocop-1.88.1.gem'
+    sha256 '726af773d6bc169ed3ff852f3ca020b7c58d39c34e7a8d879a8e0147cc994f26'
   end
 
   resource 'rubocop-ast' do

--- a/githubbuild.rb
+++ b/githubbuild.rb
@@ -4,7 +4,7 @@ class Githubbuild < Formula
   desc 'GitHub build file generator'
   homepage 'https://github.com/Cloud-Officer/github-build'
   url 'https://github.com/Cloud-Officer/github-build.git',
-      tag: '1.24.16'
+      tag: '1.24.17'
   head 'https://github.com/Cloud-Officer/github-build.git'
 
   depends_on 'ruby'
@@ -100,8 +100,8 @@ class Githubbuild < Formula
   end
 
   resource 'language_server-protocol' do
-    url 'https://rubygems.org/gems/language_server-protocol-3.17.0.5.gem'
-    sha256 'fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc'
+    url 'https://rubygems.org/gems/language_server-protocol-3.17.0.6.gem'
+    sha256 '5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0'
   end
 
   resource 'lint_roller' do
@@ -205,8 +205,8 @@ class Githubbuild < Formula
   end
 
   resource 'rubocop' do
-    url 'https://rubygems.org/gems/rubocop-1.88.0.gem'
-    sha256 'e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b'
+    url 'https://rubygems.org/gems/rubocop-1.88.1.gem'
+    sha256 '726af773d6bc169ed3ff852f3ca020b7c58d39c34e7a8d879a8e0147cc994f26'
   end
 
   resource 'rubocop-ast' do

--- a/soup.rb
+++ b/soup.rb
@@ -4,7 +4,7 @@ class Soup < Formula
   desc 'Software of Unknown Provenance'
   homepage 'https://github.com/Cloud-Officer/soup'
   url 'https://github.com/Cloud-Officer/soup.git',
-      tag: '1.9.15'
+      tag: '1.9.16'
   head 'https://github.com/Cloud-Officer/soup.git'
 
   depends_on 'ruby'
@@ -90,8 +90,8 @@ class Soup < Formula
   end
 
   resource 'language_server-protocol' do
-    url 'https://rubygems.org/gems/language_server-protocol-3.17.0.5.gem'
-    sha256 'fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc'
+    url 'https://rubygems.org/gems/language_server-protocol-3.17.0.6.gem'
+    sha256 '5ef2c0c138f8267e1bc631d3328347d354f96724b0af22f2c79516120443b7f0'
   end
 
   resource 'lint_roller' do
@@ -231,8 +231,8 @@ class Soup < Formula
   end
 
   resource 'rubocop' do
-    url 'https://rubygems.org/gems/rubocop-1.88.0.gem'
-    sha256 'e420ddf1662d0ef34bc8a2910ac4b396a7ddda0b51a708264405241734b08e0b'
+    url 'https://rubygems.org/gems/rubocop-1.88.1.gem'
+    sha256 '726af773d6bc169ed3ff852f3ca020b7c58d39c34e7a8d879a8e0147cc994f26'
   end
 
   resource 'rubocop-ast' do


### PR DESCRIPTION
## Summary

Updates the three Homebrew formulas to their latest tagged releases and refreshes the bundled Ruby gem resources to their newest versions.

**Key changes:**

- Bump `citools` formula tag from 1.7.30 to 1.7.31
- Bump `githubbuild` formula tag from 1.24.16 to 1.24.17
- Bump `soup` formula tag from 1.9.15 to 1.9.16
- Update shared gem resources: `language_server-protocol` 3.17.0.5 → 3.17.0.6 and `rubocop` 1.88.0 → 1.88.1 across all three formulas
- Update AWS SDK gem resources in `citools`: `aws-partitions` 1.1262.0 → 1.1265.0, `aws-sdk-autoscaling` 1.161.0 → 1.162.0, `aws-sdk-cloudformation` 1.154.0 → 1.155.0, `aws-sdk-ec2` 1.625.0 → 1.628.0, `aws-sdk-lambda` 1.185.0 → 1.186.0

## Types of changes

- [ ] Bugfix (fixes an issue)
- [ ] New feature (adds functionality)
- [ ] Refactoring (improves code without changing functionality)
- [ ] Breaking change (incompatible changes)
- [x] Build or security update (updates dependencies, libraries, or security patches)
- [ ] Code style or documentation update (formatting, renaming, or documentation changes)
- [ ] Other (please describe):

## Checklist

- [ ] Unit tests added to validate my fix/feature
- [x] I have manually tested my change
- [x] I did not add automation test. Why ?: Formula version/resource bumps validated by Homebrew audit/CI
- [ ] Database changes requiring migration with downtime or reprocessing of existing data
- [ ] The SOUP file lists the risk Level, requirements and verification reasoning associated with each library
- [ ] `readme.md` includes sections on introduction, installation, usage, and contributing
- [ ] `docs/architecture.md` includes sections on the architecture diagram, software units, software of unknown provenance, critical algorithms and risk controls related to PII and security
- [ ] Impact on PII, privacy regulations (CCPA/GDPR/PIPEDA), CIS benchmarks or security (availability/confidentiality/integrity); management must be notified